### PR TITLE
Set DMARC policy to reject

### DIFF
--- a/dns/openzeppelin.com-dns.tf
+++ b/dns/openzeppelin.com-dns.tf
@@ -66,12 +66,27 @@ resource "aws_route53_record" "openzeppelin_com_txt" {
   type    = "TXT"
   records = [
     "v=spf1 include:_spf.google.com ~all",
-    "v=DMARC1; p=quarantine; rua=mailto:dmarc-reports@openzeppelin.com",
     "google-site-verification=30do8MGZ29CQX6R0H5hs3Y09SUYuLIt1fbrHWBeJg98",
-    "ethbuenosaires.com._report._dmarc.openzeppelin.com",
-    "openzeppelin.org._report._dmarc.openzeppelin.com",
-    "zeppelin.solutions.com._report._dmarc.openzeppelin.com"
   ]
+}
+
+resource "aws_route53_record" "openzeppelin_com_dmarc_txt" {
+  zone_id = "${aws_route53_zone.openzeppelin_com.zone_id}"
+  name    = "_dmarc.openzeppelin.com"
+  ttl     = "300"
+  type    = "TXT"
+  records = [
+    "v=DMARC1; p=reject; rua=mailto:dmarc-reports@openzeppelin.com"
+  ]
+}
+
+resource "aws_route53_record" "openzeppelin_com_dmarc_reports" {
+  for_each = toset(["ethbuenosaires.com", "openzeppelin.org", "zeppelin.solutions.com"])
+  zone_id = "${aws_route53_zone.openzeppelin_com.zone_id}"
+  name    = "${each.key}._report._dmarc.openzeppelin.com"
+  ttl     = "300"
+  type    = "TXT"
+  records = ["v=DMARC1;"]
 }
 
 resource "aws_route53_record" "openzeppelin_com_docs" {


### PR DESCRIPTION
Sets DMARC policy to reject and fixes subdomains. Terraform `plan` is:

```
Terraform will perform the following actions:

  # aws_route53_record.openzeppelin_com_dmarc_reports["ethbuenosaires.com"] will be created
  + resource "aws_route53_record" "openzeppelin_com_dmarc_reports" {
      + allow_overwrite = (known after apply)
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = "ethbuenosaires.com._report._dmarc.openzeppelin.com"
      + records         = [
          + "v=DMARC1;",
        ]
      + ttl             = 300
      + type            = "TXT"
      + zone_id         = "Z2RVQD3OOEQTZ5"
    }

  # aws_route53_record.openzeppelin_com_dmarc_reports["openzeppelin.org"] will be created
  + resource "aws_route53_record" "openzeppelin_com_dmarc_reports" {
      + allow_overwrite = (known after apply)
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = "openzeppelin.org._report._dmarc.openzeppelin.com"
      + records         = [
          + "v=DMARC1;",
        ]
      + ttl             = 300
      + type            = "TXT"
      + zone_id         = "Z2RVQD3OOEQTZ5"
    }

  # aws_route53_record.openzeppelin_com_dmarc_reports["zeppelin.solutions.com"] will be created
  + resource "aws_route53_record" "openzeppelin_com_dmarc_reports" {
      + allow_overwrite = (known after apply)
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = "zeppelin.solutions.com._report._dmarc.openzeppelin.com"
      + records         = [
          + "v=DMARC1;",
        ]
      + ttl             = 300
      + type            = "TXT"
      + zone_id         = "Z2RVQD3OOEQTZ5"
    }

  # aws_route53_record.openzeppelin_com_dmarc_txt will be created
  + resource "aws_route53_record" "openzeppelin_com_dmarc_txt" {
      + allow_overwrite = (known after apply)
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = "_dmarc.openzeppelin.com"
      + records         = [
          + "v=DMARC1; p=reject; rua=mailto:dmarc-reports@openzeppelin.com",
        ]
      + ttl             = 300
      + type            = "TXT"
      + zone_id         = "Z2RVQD3OOEQTZ5"
    }

  # aws_route53_record.openzeppelin_com_txt will be updated in-place
  ~ resource "aws_route53_record" "openzeppelin_com_txt" {
        id      = "Z2RVQD3OOEQTZ5_openzeppelin.com_TXT"
        name    = "openzeppelin.com"
      ~ records = [
          - "ethbuenosaires.com._report._dmarc.openzeppelin.com",
          - "openzeppelin.org._report._dmarc.openzeppelin.com",
          - "v=DMARC1; p=quarantine; rua=mailto:dmarc-reports@openzeppelin.com",
          - "zeppelin.solutions.com._report._dmarc.openzeppelin.com",
            # (2 unchanged elements hidden)
        ]
        # (4 unchanged attributes hidden)
    }
```